### PR TITLE
Fixes dashboard page

### DIFF
--- a/general/networking/nginx.md
+++ b/general/networking/nginx.md
@@ -54,7 +54,7 @@ server {
     # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     # Enforces https content and restricts JS/CSS to origin
     # External Javascript (such as cast_sender.js for Chromecast) must be whitelisted.
-    #add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
+    #add_header Content-Security-Policy "default-src https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://www.gstatic.com/cv/js/sender/v1/cast_sender.js blob:; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; frame-ancestors 'self'";
 
     location = / {
         return 302 https://$host/web/;


### PR DESCRIPTION
The playbackreporting plugin dashboard is being blocked by CSP using the default configuration. Adding blob: resolves this.

Fixes: https://github.com/jellyfin/jellyfin-plugin-playbackreporting/issues/29